### PR TITLE
[BREAKING] Remove all exception handing from Request_Executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ You're really going to want to read this.
 
 ## Unreleased
 
+* [BREAKING] Remove all exception handling from Request_Executor : you will need to re-implement this
+  in index.php 
+
 ## 4.0.0 (2018-03-07)
 
 * Use setter injection rather than constructor injection for passing request / response to

--- a/classes/Request/Executor.php
+++ b/classes/Request/Executor.php
@@ -35,20 +35,17 @@ class Request_Executor
 				// Controller failed to return a Response.
 				throw new Kohana_Exception('Controller failed to return a Response');
 			}
+
+			return $response;
+
 		} catch (HTTP_Exception $e) {
 			// Store the request context in the Exception
 			if ($e->request() === NULL) {
 				$e->request($request);
 			}
-
-			// Get the response via the Exception
-			$response = $e->get_response();
-		} catch (Exception $e) {
-			// Generate an appropriate Response object
-			$response = Kohana_Exception::_handler($e);
+			throw $e;
 		}
 
-		return $response;
 	}
 
 	/**


### PR DESCRIPTION
Apps are now responsible for their own try/catch within their
index.php code. This allows for separate handling in shell tasks,
unit tests and the like and better separation of concerns : there's
no need to render a full HTML trace to the console if it's not in
web context, nor is a redirect or similar particularly helpful.