### PR TITLE
Do not throw an exception on requests to invalid URLS like //index.ph…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ You're really going to want to read this.
 
 ## Unreleased
 
+## v4.3.1 (2019-11-07)
+
 * Fix some errors in migrating unit test mocking to PHPUnit 7
 * Do not throw an exception on requests to invalid URLS like //index.php?stuff=query
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ You're really going to want to read this.
 
 ## Unreleased
 
+* Do not throw an exception on requests to invalid URLS like //index.php?stuff=query
+
 ## v4.3.0 (2019-04-02)
 
 * Drop support for PHP < 7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ You're really going to want to read this.
 
 ## Unreleased
 
+* Fix some errors in migrating unit test mocking to PHPUnit 7
 * Do not throw an exception on requests to invalid URLS like //index.php?stuff=query
 
 ## v4.3.0 (2019-04-02)

--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -141,21 +141,28 @@ class Kohana_Request implements HTTP_Request {
 
 			if (isset($_SERVER['REQUEST_URI']))
 			{
-				/**
-				 * We use REQUEST_URI as the fallback value. The reason
-				 * for this is we might have a malformed URL such as:
-				 *
-				 *  http://localhost/http://example.com/judge.php
-				 *
-				 * which parse_url can't handle. So rather than leave empty
-				 * handed, we'll use this.
-				 */
-				$uri = $_SERVER['REQUEST_URI'];
+				$uri = \parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 
-				if ($request_uri = \parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))
+				if ( ! $uri) 
 				{
-					// Valid URL path found, set it.
-					$uri = $request_uri;
+					/**
+					 * We use REQUEST_URI as the fallback value. The reason
+					 * for this is we might have a malformed URL such as:
+					 *
+					 *  http://localhost/http://example.com/judge.php
+					 *
+					 * which parse_url can't handle. So rather than leave empty
+					 * handed, we'll use this.
+					 *
+					 * This also covers urls that are not actually malformed but parse_url dislikes
+					 * such as `//index.php`.
+					 *
+					 * However, REQUEST_URI may include a querystring if one was provided, and we
+					 * need to strip that off so it behaves the same as parse_url would - otherwise
+					 * the request itself gives an exception on construction because of the QS in
+					 * the URL.
+					 */
+					 $uri = explode('?', $_SERVER['REQUEST_URI'])[0];
 				}
 
 				// Decode the request URI

--- a/tests/kohana/ConfigTest.php
+++ b/tests/kohana/ConfigTest.php
@@ -114,7 +114,7 @@ class Kohana_ConfigTest extends Unittest_TestCase
 		// To get around this we have to specify a totally random name for the second mock object
 		$reader1 = $this->createMock('Kohana_Config_Reader');
 		$reader2 = $this->getMockBuilder('Kohana_Config_Reader')
-            ->setConstructorArgs([ array(), array(), 'MY_AWESOME_READER'])
+            ->setMockClassName('MY_AWESOME_READER')
             ->getMock();
 
 		$config->attach($reader1);
@@ -155,7 +155,9 @@ class Kohana_ConfigTest extends Unittest_TestCase
 	{
 		$config = new Config;
 
-		$reader = $this->getMockBuilder('Kohana_Config_Reader')->setConstructorArgs([array('load')])->getMock();
+		$reader = $this->getMockBuilder('Kohana_Config_Reader')
+            ->setMethods(['load'])
+            ->getMock();
 
 		$reader
 			->expects($this->once())
@@ -180,7 +182,9 @@ class Kohana_ConfigTest extends Unittest_TestCase
 	{
 		$config = new Config;
 
-		$reader = $this->getMockBuilder('Kohana_Config_Reader')->setConstructorArgs([array('load')])->getMock();
+		$reader = $this->getMockBuilder('Kohana_Config_Reader')
+            ->setMethods(['load'])
+            ->getMock();
 
 		$reader
 			->expects($this->once())
@@ -261,8 +265,12 @@ class Kohana_ConfigTest extends Unittest_TestCase
 		$config = new Kohana_Config;
 
 		$reader1 = $this->createMock('Kohana_Config_Reader');
-		$writer1 = $this->getMockBuilder('Kohana_Config_Writer')->setConstructorArgs([array('write')])->getMock();
-		$writer2 = $this->getMockBuilder('Kohana_Config_Writer')->setConstructorArgs([array('write')])->getMock();
+		$writer1 = $this->getMockBuilder('Kohana_Config_Writer')
+            ->setMethods(['write'])
+            ->getMock();
+		$writer2 = $this->getMockBuilder('Kohana_Config_Writer')
+            ->setMethods(['write'])
+            ->getMock();
 
 		$writer1
 			->expects($this->once())
@@ -291,10 +299,12 @@ class Kohana_ConfigTest extends Unittest_TestCase
 		$group_name =  'lolumns';
 
 		$reader1 = $this->getMockBuilder('Kohana_Config_Reader')
-            ->setConstructorArgs([ array('load'), array(), 'Unittest_Config_Reader_1'])
+            ->setMethods(['load'])
+            ->setMockClassName('Unittest_Config_Reader_1')
             ->getMock();
 		$reader2 = $this->getMockBuilder('Kohana_Config_Reader')
-            ->setConstructorArgs([ array('load'), array(), 'Unittest_Config_Reader_2'])
+            ->setMethods(['load'])
+            ->setMockClassName('Unittest_Config_Reader_2')
             ->getMock();
 
 		$reader1
@@ -339,7 +349,9 @@ class Kohana_ConfigTest extends Unittest_TestCase
 	 */
 	public function test_load_reuses_config_groups()
 	{
-		$reader = $this->getMockBuilder('Kohana_Config_Reader')->setConstructorArgs([array('load')])->getMock();
+		$reader = $this->getMockBuilder('Kohana_Config_Reader')
+            ->setMethods(['load'])
+            ->getMock();
 		$reader
 			->expects($this->once())
 			->method('load')
@@ -366,8 +378,12 @@ class Kohana_ConfigTest extends Unittest_TestCase
 	{
 		$config = new Kohana_Config;
 
-		$reader1 = $this->getMockBuilder('Kohana_Config_Reader')->setConstructorArgs([array('load')])->getMock();
-		$reader2 = $this->getMockBuilder('Kohana_Config_Reader')->setConstructorArgs([array('load')])->getMock();
+		$reader1 = $this->getMockBuilder('Kohana_Config_Reader')
+            ->setMethods(['load'])
+            ->getMock();
+		$reader2 = $this->getMockBuilder('Kohana_Config_Reader')
+            ->setMethods(['load'])
+            ->getMock();
 
 		$reader1
 			->expects($this->once())
@@ -381,8 +397,12 @@ class Kohana_ConfigTest extends Unittest_TestCase
 			->with('something')
 			->will($this->returnValue(array('kohana' => 'good')));
 
-		$writer1 = $this->getMockBuilder('Kohana_Config_Writer')->setConstructorArgs([array('write')])->getMock();
-		$writer2 = $this->getMockBuilder('Kohana_Config_Writer')->setConstructorArgs([array('write')])->getMock();
+		$writer1 = $this->getMockBuilder('Kohana_Config_Writer')
+            ->setMethods(['write'])
+            ->getMock();
+		$writer2 = $this->getMockBuilder('Kohana_Config_Writer')
+            ->setMethods(['write'])
+            ->getMock();
 
 		// Due to crazy limitations in phpunit's mocking engine we have to be fairly
 		// liberal here as to what order we receive the config items


### PR DESCRIPTION
…p?stuff=query

Various vulnerability probes and similar bots attempt to access urls that are
valid but unusual - e.g. //index.php?{some query string}. These generally
do not get interpreted the same way as normal URLs by apache etc, so drop
into Kohana's fallback URL handler. This should be stripping the querystring
from the text, consistent with the normal flow, but was not doing so.

Although these kinds of bot requests were being rejected, they were doing
so with a 500 and an error log entry, rather than a simple 404.

Fix the fallback handling so that it strips the querystring and works for
all URLs without errors.