### PR TITLE
Fix TypeError on Upload::not_empty when file is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ You're really going to want to read this.
 
 ## Unreleased
 
+* Handle potentially empty (null) file argument for Kohana_Upload::not_empty (fixes 
+  TypeError from the explicit array typehint on that method.
+
 ## v4.3.2 (2019-12-10)
 
 * Update list of Response status codes to IANA list as at 2018-09-01

--- a/classes/Kohana/Upload.php
+++ b/classes/Kohana/Upload.php
@@ -126,9 +126,10 @@ class Kohana_Upload {
 	 * @param   array   $file   $_FILES item
 	 * @return  bool
 	 */
-	public static function not_empty(array $file)
+	public static function not_empty($file)
 	{
-		return (isset($file['error'])
+		return is_array($file)
+			AND (isset($file['error'])
 			AND isset($file['tmp_name'])
 			AND $file['error'] === UPLOAD_ERR_OK
 			AND \is_uploaded_file($file['tmp_name']));

--- a/tests/kohana/UploadTest.php
+++ b/tests/kohana/UploadTest.php
@@ -112,7 +112,42 @@ class Kohana_UploadTest extends Unittest_TestCase
 		Upload::size($_FILES['unit_test'], '1DooDah');
 	}
 
-	/**
+    public function provider_not_empty()
+    {
+        return [
+            [
+                NULL,
+                FALSE
+            ],
+            [
+                '',
+                FALSE
+            ],
+            [
+                [],
+                FALSE
+            ],
+            [
+                ['error' => UPLOAD_ERR_CANT_WRITE, 'tmp_name' => uniqid(sys_get_temp_dir())],
+                FALSE
+            ],
+//            [
+//                // Can't test in reality for the passing case as it calls is_uploaded_file
+//                ['error' => UPLOAD_ERR_OK, 'tmp_name' => uniqid(sys_get_temp_dir())],
+//                TRUE
+//            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provider_not_empty
+     */
+    public function test_not_empty($to_validate, $expect)
+    {
+        $this->assertSame($expect, Upload::not_empty($to_validate));
+    }
+
+    /**
 	 * Provides test data for test_valid()
 	 *
      * Not clear if this is actually testing anything as well as being a data provider
@@ -180,7 +215,7 @@ class Kohana_UploadTest extends Unittest_TestCase
 					'tmp_name' => Kohana::find_file('tests', 'test_data/github', 'png'),
 				)
 			),
-			
+
 		);
 	}
 


### PR DESCRIPTION
The current strict `array` hint causes the method to fail if the
value is actually null / missing as it may be in an POST if the
file did not get uploaded as expected. Instead, just treat this
as any usual validation error.