### PR TITLE
Do not throw any exception on requests containing a ? in the URL, tre…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@ You're really going to want to read this.
 
 ## Unreleased
 
+* [NB] Do not throw any exception on requests containing a ? in the URL, treat it as literal.
+  If a user-agent has sent a request containing an encoded `?` character, this is correctly
+  treated by the webserver as an escaped literal character that forms part of the URL path /
+  filename, not a querystring separator. In this case the `?` appears in PATH_INFO and the
+  app should likewise treat it as a valid URL containing a `?`. This, of course, may not
+  match any defined route but that is for the routing layer to handle and 404 as required.
+  The exception was primarily added by us to catch legacy behaviour e.g. unit tests that
+  were creating a request object with a `?a=b` in the URL and relying on that being parsed
+  as a querystring in the returned object. This warning/failure is no longer available.
 * Handle potentially empty (null) file argument for Kohana_Upload::not_empty (fixes 
   TypeError from the explicit array typehint on that method.
 

--- a/classes/Kohana/Request.php
+++ b/classes/Kohana/Request.php
@@ -556,11 +556,6 @@ class Kohana_Request implements HTTP_Request {
 		// Initialise the header
 		$this->_header = new HTTP_Header(array());
 
-		if (\strpos($uri, '?') !== FALSE) {
-			// This shouldn't be happening, the arguments should be pre-parsed to the base url and the $_GET array
-			throw new \UnexpectedValueException('Cannot accept querystring arguments in \Request::$uri');
-		}
-
 		// Fail if they're trying to do old-school external request execution
 		if (\strpos($uri, '://') === FALSE)
 		{

--- a/tests/kohana/RequestTest.php
+++ b/tests/kohana/RequestTest.php
@@ -550,12 +550,11 @@ class Kohana_RequestTest extends Unittest_TestCase
 		$this->assertSame($expect, \Request::fromGlobals()->query($key));
 	}
 
-	/**
-	 * @expectedException \UnexpectedValueException
-	 */
-	public function test_throws_if_creating_with_query_string_in_url()
+	public function test_creating_with_questionmark_in_url_creates_with_literal_url_and_no_query()
 	{
-		\Request::with(['uri' => 'some/url?with=a&query=string']);
+		$rq = \Request::with(['uri' => 'some/url?with=a&query=string']);
+		$this->assertSame('some/url?with=a&query=string', $rq->uri());
+		$this->assertSame([], $rq->query());
 	}
 
 	public function test_it_trims_basic_string_value()


### PR DESCRIPTION
…at it as literal.

If a user-agent has sent a request containing an encoded `?` character, this is correctly
treated by the webserver as an escaped literal character that forms part of the URL path /
filename, not a querystring separator. In this case the `?` appears in PATH_INFO and the
app should likewise treat it as a valid URL containing a `?`. This, of course, may not
match any defined route but that is for the routing layer to handle and 404 as required.

The exception was primarily added by us to catch legacy behaviour e.g. unit tests that
were creating a request object with a `?a=b` in the URL and relying on that being parsed
as a querystring in the returned object. This warning/failure is no longer available.