### PR TITLE
Reduce default error page verbosity outside local dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ You're really going to want to read this.
 
 ## Unreleased
 
+* [NB] Changes the default HTML error view to one that does not render environment, method
+  call params and other internal details. The stack trace is still shown to aid debugging,
+  and it's possible that exception messages will show sensitive information, but this
+  significantly reduces the default exposure when custom error handling goes wrong or has
+  not yet been initialised. The old kohana error dump view is enabled in the
+  `Kohana::DEVELOPMENT` environment for local debugging. As with the cli error you can
+   customise the template by passing `[error_view => 'name_of_view']` to Kohana::init().
+
 ## v4.4.0 (2020-01-30)
 
 * [NB] Now defines a default cli_error view if the PHP_SAPI==='cli', rather than the default

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -224,7 +224,9 @@ class Kohana_Core {
 			\Kohana_Exception::$error_view = $settings['error_view'];
 		} elseif (PHP_SAPI === 'cli') {
 			\Kohana_Exception::$error_view = 'kohana/cli_error';
-		}
+		} elseif (\Kohana::$environment === \Kohana::DEVELOPMENT) {
+		    \Kohana_Exception::$error_view = 'kohana/dev_html_error';
+        }
 
 		/**
 		 * Enable xdebug parameter collection in development mode to improve fatal stack traces.

--- a/views/kohana/dev_html_error.php
+++ b/views/kohana/dev_html_error.php
@@ -1,0 +1,129 @@
+<?php \defined('SYSPATH') OR die('No direct script access.') ?>
+<?php
+
+// Unique error identifier
+$error_id = \uniqid('error');
+
+?>
+<style type="text/css">
+#kohana_error { background: #ddd; font-size: 1em; font-family:sans-serif; text-align: left; color: #111; }
+#kohana_error h1,
+#kohana_error h2 { margin: 0; padding: 1em; font-size: 1em; font-weight: normal; background: #911; color: #fff; }
+	#kohana_error h1 a,
+	#kohana_error h2 a { color: #fff; }
+#kohana_error h2 { background: #222; }
+#kohana_error h3 { margin: 0; padding: 0.4em 0 0; font-size: 1em; font-weight: normal; }
+#kohana_error p { margin: 0; padding: 0.2em 0; }
+#kohana_error a { color: #1b323b; }
+#kohana_error pre { overflow: auto; white-space: pre-wrap; }
+#kohana_error table { width: 100%; display: block; margin: 0 0 0.4em; padding: 0; border-collapse: collapse; background: #fff; }
+	#kohana_error table td { border: solid 1px #ddd; text-align: left; vertical-align: top; padding: 0.4em; }
+#kohana_error div.content { padding: 0.4em 1em 1em; overflow: hidden; }
+#kohana_error pre.source { margin: 0 0 1em; padding: 0.4em; background: #fff; border: dotted 1px #b7c680; line-height: 1.2em; }
+	#kohana_error pre.source span.line { display: block; }
+	#kohana_error pre.source span.highlight { background: #f0eb96; }
+		#kohana_error pre.source span.line span.number { color: #666; }
+#kohana_error ol.trace { display: block; margin: 0 0 0 2em; padding: 0; list-style: decimal; }
+	#kohana_error ol.trace li { margin: 0; padding: 0; }
+.js .collapsed { display: none; }
+</style>
+<script type="text/javascript">
+document.documentElement.className = document.documentElement.className + ' js';
+function koggle(elem)
+{
+	elem = document.getElementById(elem);
+
+	if (elem.style && elem.style['display'])
+		// Only works with the "style" attr
+		var disp = elem.style['display'];
+	else if (elem.currentStyle)
+		// For MSIE, naturally
+		var disp = elem.currentStyle['display'];
+	else if (window.getComputedStyle)
+		// For most other browsers
+		var disp = document.defaultView.getComputedStyle(elem, null).getPropertyValue('display');
+
+	// Toggle the state of the "display" style
+	elem.style.display = disp == 'block' ? 'none' : 'block';
+	return false;
+}
+</script>
+<div id="kohana_error">
+	<h1><span class="type"><?php echo $class ?> [ <?php echo $code ?> ]:</span> <span class="message"><?php echo \htmlspecialchars( (string) $message, ENT_QUOTES | ENT_IGNORE, Kohana::$charset, TRUE); ?></span></h1>
+	<div id="<?php echo $error_id ?>" class="content">
+		<p><span class="file"><?php echo Debug::path($file) ?> [ <?php echo $line ?> ]</span></p>
+		<?php echo Debug::source($file, $line) ?>
+		<ol class="trace">
+		<?php foreach (Debug::trace($trace) as $i => $step): ?>
+			<li>
+				<p>
+					<span class="file">
+						<?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
+							<a href="#<?php echo $source_id ?>" onclick="return koggle('<?php echo $source_id ?>')"><?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]</a>
+						<?php else: ?>
+							{<?php echo __('PHP internal call') ?>}
+						<?php endif ?>
+					</span>
+					&raquo;
+					<?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo __('arguments') ?></a><?php endif ?>)
+				</p>
+				<?php if (isset($args_id)): ?>
+				<div id="<?php echo $args_id ?>" class="collapsed">
+					<table cellspacing="0">
+					<?php foreach ($step['args'] as $name => $arg): ?>
+						<tr>
+							<td><code><?php echo $name ?></code></td>
+							<td><pre><?php echo Debug::dump($arg) ?></pre></td>
+						</tr>
+					<?php endforeach ?>
+					</table>
+				</div>
+				<?php endif ?>
+				<?php if (isset($source_id)): ?>
+					<pre id="<?php echo $source_id ?>" class="source collapsed"><code><?php echo $step['source'] ?></code></pre>
+				<?php endif ?>
+			</li>
+			<?php unset($args_id, $source_id); ?>
+		<?php endforeach ?>
+		</ol>
+	</div>
+	<h2><a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Environment') ?></a></h2>
+	<div id="<?php echo $env_id ?>" class="content collapsed">
+		<?php $included = \get_included_files() ?>
+		<h3><a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Included files') ?></a> (<?php echo \count($included) ?>)</h3>
+		<div id="<?php echo $env_id ?>" class="collapsed">
+			<table cellspacing="0">
+				<?php foreach ($included as $file): ?>
+				<tr>
+					<td><code><?php echo Debug::path($file) ?></code></td>
+				</tr>
+				<?php endforeach ?>
+			</table>
+		</div>
+		<?php $included = \get_loaded_extensions() ?>
+		<h3><a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Loaded extensions') ?></a> (<?php echo \count($included) ?>)</h3>
+		<div id="<?php echo $env_id ?>" class="collapsed">
+			<table cellspacing="0">
+				<?php foreach ($included as $file): ?>
+				<tr>
+					<td><code><?php echo Debug::path($file) ?></code></td>
+				</tr>
+				<?php endforeach ?>
+			</table>
+		</div>
+		<?php foreach (array('_SESSION', '_GET', '_POST', '_FILES', '_COOKIE', '_SERVER') as $var): ?>
+		<?php if (empty($GLOBALS[$var]) OR ! \is_array($GLOBALS[$var])) continue ?>
+		<h3><a href="#<?php echo $env_id = $error_id.'environment'.\strtolower($var) ?>" onclick="return koggle('<?php echo $env_id ?>')">$<?php echo $var ?></a></h3>
+		<div id="<?php echo $env_id ?>" class="collapsed">
+			<table cellspacing="0">
+				<?php foreach ($GLOBALS[$var] as $key => $value): ?>
+				<tr>
+					<td><code><?php echo \htmlspecialchars( (string) $key, ENT_QUOTES, Kohana::$charset, TRUE); ?></code></td>
+					<td><pre><?php echo Debug::dump($value) ?></pre></td>
+				</tr>
+				<?php endforeach ?>
+			</table>
+		</div>
+		<?php endforeach ?>
+	</div>
+</div>

--- a/views/kohana/error.php
+++ b/views/kohana/error.php
@@ -1,129 +1,66 @@
-<?php \defined('SYSPATH') OR die('No direct script access.') ?>
 <?php
-
-// Unique error identifier
-$error_id = \uniqid('error');
+/**
+ * Generic error page for errors on web. Note that this is NOT a full View model, and the template
+ * and other classes are not available.
+ * This view should be as simple as humanly possible to avoid any potential cascade in errors,
+ *
+ * @var Exception $e
+ * @var array     $trace
+ * @var string    $file
+ * @var string    $line
+ * @var string    $message
+ * @var string    $code
+ */
 
 ?>
-<style type="text/css">
-#kohana_error { background: #ddd; font-size: 1em; font-family:sans-serif; text-align: left; color: #111; }
-#kohana_error h1,
-#kohana_error h2 { margin: 0; padding: 1em; font-size: 1em; font-weight: normal; background: #911; color: #fff; }
-	#kohana_error h1 a,
-	#kohana_error h2 a { color: #fff; }
-#kohana_error h2 { background: #222; }
-#kohana_error h3 { margin: 0; padding: 0.4em 0 0; font-size: 1em; font-weight: normal; }
-#kohana_error p { margin: 0; padding: 0.2em 0; }
-#kohana_error a { color: #1b323b; }
-#kohana_error pre { overflow: auto; white-space: pre-wrap; }
-#kohana_error table { width: 100%; display: block; margin: 0 0 0.4em; padding: 0; border-collapse: collapse; background: #fff; }
-	#kohana_error table td { border: solid 1px #ddd; text-align: left; vertical-align: top; padding: 0.4em; }
-#kohana_error div.content { padding: 0.4em 1em 1em; overflow: hidden; }
-#kohana_error pre.source { margin: 0 0 1em; padding: 0.4em; background: #fff; border: dotted 1px #b7c680; line-height: 1.2em; }
-	#kohana_error pre.source span.line { display: block; }
-	#kohana_error pre.source span.highlight { background: #f0eb96; }
-		#kohana_error pre.source span.line span.number { color: #666; }
-#kohana_error ol.trace { display: block; margin: 0 0 0 2em; padding: 0; list-style: decimal; }
-	#kohana_error ol.trace li { margin: 0; padding: 0; }
-.js .collapsed { display: none; }
-</style>
-<script type="text/javascript">
-document.documentElement.className = document.documentElement.className + ' js';
-function koggle(elem)
-{
-	elem = document.getElementById(elem);
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Sorry, there was a problem</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+</head>
 
-	if (elem.style && elem.style['display'])
-		// Only works with the "style" attr
-		var disp = elem.style['display'];
-	else if (elem.currentStyle)
-		// For MSIE, naturally
-		var disp = elem.currentStyle['display'];
-	else if (window.getComputedStyle)
-		// For most other browsers
-		var disp = document.defaultView.getComputedStyle(elem, null).getPropertyValue('display');
+<body>
+	<!-- Begin page content -->
+	<div class="container">
+		<div class="row">
+			<div class="col-md-6 col-md-push-3">
+				<div class="panel panel-danger">
+					<div class="panel-heading">Sorry, there was an error processing your request</div>
+					<div class="panel-body">
+						<p>
+							<strong><?=HTML::chars($message)?></strong>
+							<small><?=HTML::chars($class)?></small>
+						</p>
+						<p>
+							Please refresh your page to try again, or use the back button to go back.
+							If this keeps happening please report it.
+						</p>
+					</div>
+					<div class="panel-footer">
+						<small>At <?=Debug::path($file)?> [ <?=HTML::chars($line);?> ] </small>
+						<ul>
+							<?php foreach($trace as $step): ?>
+								<li>
+									<small>
+									<?php if (isset($step['file'])): ?>
+										<?=Debug::path($step['file']) ?> [ <?=$step['line'] ?> ]
+									<?php else: ?>
+										{'PHP internal call'}
+									<?php endif ?>
+									</small>
+								</li>
+							<?php endforeach; ?>
+						</ul>
+					</div>
 
-	// Toggle the state of the "display" style
-	elem.style.display = disp == 'block' ? 'none' : 'block';
-	return false;
-}
-</script>
-<div id="kohana_error">
-	<h1><span class="type"><?php echo $class ?> [ <?php echo $code ?> ]:</span> <span class="message"><?php echo \htmlspecialchars( (string) $message, ENT_QUOTES | ENT_IGNORE, Kohana::$charset, TRUE); ?></span></h1>
-	<div id="<?php echo $error_id ?>" class="content">
-		<p><span class="file"><?php echo Debug::path($file) ?> [ <?php echo $line ?> ]</span></p>
-		<?php echo Debug::source($file, $line) ?>
-		<ol class="trace">
-		<?php foreach (Debug::trace($trace) as $i => $step): ?>
-			<li>
-				<p>
-					<span class="file">
-						<?php if ($step['file']): $source_id = $error_id.'source'.$i; ?>
-							<a href="#<?php echo $source_id ?>" onclick="return koggle('<?php echo $source_id ?>')"><?php echo Debug::path($step['file']) ?> [ <?php echo $step['line'] ?> ]</a>
-						<?php else: ?>
-							{<?php echo __('PHP internal call') ?>}
-						<?php endif ?>
-					</span>
-					&raquo;
-					<?php echo $step['function'] ?>(<?php if ($step['args']): $args_id = $error_id.'args'.$i; ?><a href="#<?php echo $args_id ?>" onclick="return koggle('<?php echo $args_id ?>')"><?php echo __('arguments') ?></a><?php endif ?>)
-				</p>
-				<?php if (isset($args_id)): ?>
-				<div id="<?php echo $args_id ?>" class="collapsed">
-					<table cellspacing="0">
-					<?php foreach ($step['args'] as $name => $arg): ?>
-						<tr>
-							<td><code><?php echo $name ?></code></td>
-							<td><pre><?php echo Debug::dump($arg) ?></pre></td>
-						</tr>
-					<?php endforeach ?>
-					</table>
 				</div>
-				<?php endif ?>
-				<?php if (isset($source_id)): ?>
-					<pre id="<?php echo $source_id ?>" class="source collapsed"><code><?php echo $step['source'] ?></code></pre>
-				<?php endif ?>
-			</li>
-			<?php unset($args_id, $source_id); ?>
-		<?php endforeach ?>
-		</ol>
+			</div>
+		</div>
 	</div>
-	<h2><a href="#<?php echo $env_id = $error_id.'environment' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Environment') ?></a></h2>
-	<div id="<?php echo $env_id ?>" class="content collapsed">
-		<?php $included = \get_included_files() ?>
-		<h3><a href="#<?php echo $env_id = $error_id.'environment_included' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Included files') ?></a> (<?php echo \count($included) ?>)</h3>
-		<div id="<?php echo $env_id ?>" class="collapsed">
-			<table cellspacing="0">
-				<?php foreach ($included as $file): ?>
-				<tr>
-					<td><code><?php echo Debug::path($file) ?></code></td>
-				</tr>
-				<?php endforeach ?>
-			</table>
-		</div>
-		<?php $included = \get_loaded_extensions() ?>
-		<h3><a href="#<?php echo $env_id = $error_id.'environment_loaded' ?>" onclick="return koggle('<?php echo $env_id ?>')"><?php echo __('Loaded extensions') ?></a> (<?php echo \count($included) ?>)</h3>
-		<div id="<?php echo $env_id ?>" class="collapsed">
-			<table cellspacing="0">
-				<?php foreach ($included as $file): ?>
-				<tr>
-					<td><code><?php echo Debug::path($file) ?></code></td>
-				</tr>
-				<?php endforeach ?>
-			</table>
-		</div>
-		<?php foreach (array('_SESSION', '_GET', '_POST', '_FILES', '_COOKIE', '_SERVER') as $var): ?>
-		<?php if (empty($GLOBALS[$var]) OR ! \is_array($GLOBALS[$var])) continue ?>
-		<h3><a href="#<?php echo $env_id = $error_id.'environment'.\strtolower($var) ?>" onclick="return koggle('<?php echo $env_id ?>')">$<?php echo $var ?></a></h3>
-		<div id="<?php echo $env_id ?>" class="collapsed">
-			<table cellspacing="0">
-				<?php foreach ($GLOBALS[$var] as $key => $value): ?>
-				<tr>
-					<td><code><?php echo \htmlspecialchars( (string) $key, ENT_QUOTES, Kohana::$charset, TRUE); ?></code></td>
-					<td><pre><?php echo Debug::dump($value) ?></pre></td>
-				</tr>
-				<?php endforeach ?>
-			</table>
-		</div>
-		<?php endforeach ?>
-	</div>
-</div>
+	<!-- /container -->
+</body>
+</html>
+


### PR DESCRIPTION
Switches to a more sanitised custom error page by default, retaining
the old one in the Kohana::DEVELOPMENT environment.