### PR TITLE
Include previous exception in Session_Exception when read fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ You're really going to want to read this.
 
 ## Unreleased
 
+## v4.5.0 (2020-02-14)
+
 * Include previous exception in Session_Exception when reading the session fails:
   can be retrieved for logging / debugging with
   `} catch (SessionException $e) { $cause = $e->getPrevious(); }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ You're really going to want to read this.
 
 ## Unreleased
 
+* Include previous exception in Session_Exception when reading the session fails:
+  can be retrieved for logging / debugging with
+  `} catch (SessionException $e) { $cause = $e->getPrevious(); }`
 * [NB] Changes the default HTML error view to one that does not render environment, method
   call params and other internal details. The stack trace is still shown to aid debugging,
   and it's possible that exception messages will show sensitive information, but this

--- a/classes/Kohana/Session.php
+++ b/classes/Kohana/Session.php
@@ -294,7 +294,13 @@ abstract class Kohana_Session {
 		catch (Exception $e)
 		{
 			// Error reading the session, usually a corrupt session.
-			throw new Session_Exception('Error reading session data.', NULL, Session_Exception::SESSION_CORRUPT);
+			// Can identify the cause in a catch block with $e->getPrevious()
+			throw new Session_Exception(
+				'Error reading session data.',
+				NULL,
+				Session_Exception::SESSION_CORRUPT,
+				$e
+			);
 		}
 
 		if (\is_array($data))


### PR DESCRIPTION
Allows calling code to handle / log / debug when the read fails
by making it possible to access the root cause exception which
kohana used to bury away.