### PR TITLE
Fix race-condition related exception creating cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ You're really going to want to read this.
 
 ## Unreleased
 
+## 4.8.1 (2021-02-09)
+
+* Fix race-condition related exception creating cache directory during concurrent requests. 
+
 ## 4.8.0 (2020-12-15)
 
 * [BREAKING] Removed attempts to detect whether the request came in over SSL. This is challenging to implement reliably


### PR DESCRIPTION
Concurrent requests can mean that two processes try to create the
cache directory simultaneously, which will cause one mkdir call
to fail with an exception. Check if the directory now exists
before rethrowing this.