### PR TITLE
Fix further race conditions when creating directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ You're really going to want to read this.
 
 ## Unreleased
 
+## 4.8.2 (2021-02-16)
+
+* Fix further directory-creation race conditions - replace all internal `mkdir` with the now-public 
+  `Kohana::ensureDirectory` method which gracefully handles concurrent create requests.
+
 ## 4.8.1 (2021-02-09)
 
 * Fix race-condition related exception creating cache directory during concurrent requests. 

--- a/classes/Kohana/Log/File.php
+++ b/classes/Kohana/Log/File.php
@@ -48,35 +48,20 @@ class Kohana_Log_File extends Log_Writer {
 	 */
 	public function write(array $messages)
 	{
-		// Set the yearly directory name
-		$directory = $this->_directory.\date('Y');
-
-		if ( ! \is_dir($directory))
-		{
-			// Create the yearly directory
-			\mkdir($directory, 02777);
-
-			// Set permissions (must be manually set to fix umask issues)
-			\chmod($directory, 02777);
-		}
-
-		// Add the month to the directory
-		$directory .= DIRECTORY_SEPARATOR.\date('m');
-
-		if ( ! \is_dir($directory))
-		{
-			// Create the monthly directory
-			\mkdir($directory, 02777);
-
-			// Set permissions (must be manually set to fix umask issues)
-			\chmod($directory, 02777);
-		}
+		// Set the year/month directory name
+		$directory = $this->_directory.\date('Y').DIRECTORY_SEPARATOR.\date('m');
+		Kohana::ensureDirectory($directory, 02777);
 
 		// Set the name of the log file
 		$filename = $directory.DIRECTORY_SEPARATOR.\date('d').EXT;
 
 		if ( ! \file_exists($filename))
 		{
+		    // CAUTION: there is still a theoretical race condition here where two processes might both create the
+            // file with the banner and their own entry, the second overwriting the first. This is tricky to solve
+            // without altering the log format (e.g. removing the banner so everyone can use FILE_APPEND). As we don't
+            // use Log_File any more this is left unchanged.
+            
 			// Create the log file
 			\file_put_contents($filename, Kohana::FILE_SECURITY.' ?>'.PHP_EOL);
 


### PR DESCRIPTION
Replaced all use of `mkdir` with the race-safe helper and
simplified the code to make the `is_dir` check part of the
helper too.