### PR TITLE
Don't override session_cache_limiter when starting a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@ You're really going to want to read this.
 
 ## Unreleased
 
+## 4.10.0 (2022-11-09)
+
+* [BEHAVIOUR CHANGE] Kohana no longer overrides the PHP default session_cache_limiter option
+  when starting a session. If you have referenced the session at all during the request, PHP
+  will by default now set response headers of `Expires: Thu, 19 Nov 1981 08:52:00 GMT`,
+  `Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0` and
+  `Pragma: no-cache`. You can override these at controller level if required, or restore the
+  previous behaviour by either configuring `session.cache_limiter` in php.ini or calling
+  `session_cache_limiter()` before you open the session.
+
 ## 4.9.1 (2022-10-28)
 
 * Fix deprecation warnings when passing NULL to string handling functions

--- a/classes/Kohana/Session/Native.php
+++ b/classes/Kohana/Session/Native.php
@@ -50,9 +50,6 @@ class Kohana_Session_Native extends Session {
 			Cookie::$httponly
 		);
 
-		// Do not allow PHP to send Cache-Control headers
-		\session_cache_limiter(FALSE);
-
 		// Set the session cookie name
 		\session_name($this->_name);
 


### PR DESCRIPTION
As of 3.0.8 (commit 838385eb50fe2606302411663978eea645ec5e701) kohana was calling `session_cache_limiter(FALSE)`. This prevented php setting any default cache-control headers on responses regardless of the configuration of `session.cache_limiter` in php.ini. The behaviour was not optional, overridable, or documented.

That commit was apparently added to fix a bug on the old kohana issue tracker, which is no longer available.

We don't think this is a sane default - if handling the request involved reading or writing $_SESSION then it is more likely than not that the response should not be cached.

Applications that do want some or all responses to be cached regardless of session state can still configure this either by setting response headers in specific controllers or by customising the php ini configuration of `session.cache_limiter`.