### PR TITLE
Fix race condition attempting to read cache files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ You're really going to want to read this.
 
 ## Unreleased
 
+## 4.12.1 (2025-01-16)
+
+* Fix race condition attempting to read cache files causing error from `find_file`
+
 ## 4.12.0 (2024-09-24)
 
 * Support PHP 8.3

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -281,8 +281,8 @@ class Kohana_Core {
 
 		if (Kohana::$caching === TRUE)
 		{
-			// Load the file path cache
-			Kohana::$_files = Kohana::cache('Kohana::find_file()');
+			// Load the file path cache if present
+			Kohana::$_files = Kohana::cache('Kohana::find_file()') ?? [];
 		}
 
 		if (isset($settings['charset']))
@@ -902,7 +902,15 @@ class Kohana_Core {
 					// Return the cache
 					try
 					{
-						return \unserialize(\file_get_contents($dir.$file));
+						$content = \file_get_contents($dir.$file);
+						if ($content === FALSE)
+						{
+							// Cache has been removed since the `is_file` call above e.g. it is on the moment of expiry
+							// Treat as cache miss
+							return NULL;
+						}
+
+						return \unserialize($content);
 					}
 					catch (Exception $e)
 					{


### PR DESCRIPTION
We were very occasionally seeing an error `PHP Warning: ErrorException: Automatic conversion of false to array is deprecated in .../classes/Kohana/Core.php:746` in particular when a site is under heavy load.

This was caused by `Kohana::cache('Kohana::find_file()')` returning `false` (rather than `null` or `array`). That can only have been coming from the result of the `unserialize(file_get_contents($dir.$file)` call. The most likely cause of that would be `file_get_contents` returning false due to a race condition where the file existed at the start of the if block but no longer existing by the time we attempt to read the file.

My assumption is that with concurrent requests at the exact moment of cache expiry it is possible for one request to delete the file just before the other request tries to read it.

With this change we treat the failed read as any other failure to unserialise the cache file and just return null. Additionally we cast the null to `[]` specifically when loading the `find_files` cache so that we can guarantee the `Kohana::$files` will always be an array.