### PR TITLE
fix: deprecation attempting to delete a cookie by setting value to NULL

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
           - '8.2'
           - '8.3'
         dependencies:
-          - 'default'
+          - 'highest'
         koharness_modules:
           - 'all-modules'
           - 'core-only'
@@ -44,30 +44,14 @@ jobs:
           tools: composer:v2
 
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-${{ matrix.dependencies }}
+        uses: actions/checkout@v4
 
       - name: Install composer dependencies
+        uses: ramsey/composer-install@v3
         env:
-          DEPENDENCIES: ${{ matrix.dependencies }}
-        run: |
-          if [ $DEPENDENCIES == 'lowest' ]
-          then
-            COMPOSER_ROOT_VERSION=3.3.x-dev composer update --prefer-lowest --no-interaction --no-progress
-          else
-            COMPOSER_ROOT_VERSION=3.3.x-dev composer install --no-interaction --no-progress
-          fi
+          COMPOSER_ROOT_VERSION: 3.3.x-dev
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
 
       - name: Run koharness
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ You're really going to want to read this.
 
 ## Unreleased
 
+## 4.12.2 (2025-06-23)
+
+* Fix deprecation when attempting to delete a cookie by setting value to NULL
+
 ## 4.12.1 (2025-01-16)
 
 * Fix race condition attempting to read cache files causing error from `find_file`

--- a/classes/Kohana/Cookie.php
+++ b/classes/Kohana/Cookie.php
@@ -178,7 +178,7 @@ class Kohana_Cookie {
 	}
 
 	/**
-	 * Deletes a cookie by making the value NULL and expiring it.
+	 * Deletes a cookie by making the value empty and expiring it.
 	 *
 	 *     Cookie::delete('theme');
 	 *
@@ -190,8 +190,8 @@ class Kohana_Cookie {
 		// Remove the cookie
 		unset($_COOKIE[$name]);
 
-		// Nullify the cookie and make it expire
-		return static::_setcookie($name, NULL, -86400, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
+		// Empty the cookie and make it expire
+		return static::_setcookie($name, '', -86400, Cookie::$path, Cookie::$domain, Cookie::$secure, Cookie::$httponly);
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,6 @@
 		"kohana/minion": "3.3.*",
 		"kohana/unittest": "3.3.*"
 	},
-	"conflict": {
-		"kohana/core": "*"
-	},
 	"suggest": {
 		"ext-http":   "*",
 		"ext-curl":   "*"

--- a/tests/kohana/CookieTest.php
+++ b/tests/kohana/CookieTest.php
@@ -375,10 +375,10 @@ class Kohana_CookieTest extends Unittest_TestCase
 		// @codingStandardsIgnoreEnd
 	{
 		$this->assertArrayNotHasKey($name, $_COOKIE);
-		// To delete the client-side cookie, Cookie::delete should send a new cookie with value NULL and expiry in the past
+		// To delete the client-side cookie, Cookie::delete should send a new cookie with empty value and expiry in the past
 		$this->assertSetCookieWith([
 			'name'     => $name,
-			'value'    => NULL,
+			'value'    => '',
 			'expire'   => -86400,
 			'path'     => Cookie::$path,
 			'domain'   => Cookie::$domain,
@@ -398,7 +398,7 @@ class Kohana_CookieTest extends Unittest_TestCase
 	{
 		$this->assertCount(1, Kohana_CookieTest_TestableCookie::$_mock_cookies_set);
 		$relevant_values = array_intersect_key(Kohana_CookieTest_TestableCookie::$_mock_cookies_set[0], $expected);
-		$this->assertEquals($expected, $relevant_values);
+		$this->assertSame($expected, $relevant_values);
 	}
 
 	/**


### PR DESCRIPTION
`setcookie` no longer accepts a `NULL` value - the value should instead be empty string. This was not detected by unit tests because the setcookie call is mocked for testing (because it would otherwise fail with an error that headers cannot be written due to phpunit already having written output).