### PR TITLE
!fix: further error case in `find_file` when cache read hits a race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ You're really going to want to read this.
 
 ## 4.12.2 (2025-06-23)
 
+* Fix further error case in `find_file` when cache read hits a race condition
+  **NOTE** This adds a strict `array` typehint to the protected `Kohana_Core::$_files`.
 * Fix deprecation when attempting to delete a cookie by setting value to NULL
 
 ## 4.12.1 (2025-01-16)

--- a/classes/Kohana/Core.php
+++ b/classes/Kohana/Core.php
@@ -144,7 +144,7 @@ class Kohana_Core {
 	/**
 	 * @var  array   File path cache, used when caching is true in [Kohana::init]
 	 */
-	protected static $_files = array();
+	protected static array $_files = array();
 
 	/**
 	 * @var  boolean  Has the file path cache changed during this execution?  Used internally when when caching is true in [Kohana::init]
@@ -282,7 +282,7 @@ class Kohana_Core {
 		if (Kohana::$caching === TRUE)
 		{
 			// Load the file path cache if present
-			Kohana::$_files = Kohana::cache('Kohana::find_file()') ?? [];
+			Kohana::$_files = Kohana::cache('Kohana::find_file()') ?: [];
 		}
 
 		if (isset($settings['charset']))


### PR DESCRIPTION
The fix in #47 (released in 4.12.1) has reduced the frequency of this error but has not eliminated it. There appears to be a remaining edge case / race condition where the `Kohana::cache` method can return FALSE rather than NULL.

This has proved difficult to replicate, the most likely explanation appears to be that in certain conditions either the cache is being serialized with an explicit `false` value, or that the `unserialize` is somehow returning false without raising a PHP error (or at least that this is not translated to an Exception).

Attempt to resolve by casting all falsey cache values to an empty array.

Additionally, strictly type the protected `Kohana_Core::$_files` property as an array so that any remaining attempt to assign it as `false` will trigger an error rather than this only being logged when the code subsequently attempts to read it. This is technically a BC break, but we do not expect any class to extend this property.