### PR TITLE
feat: Serve a generic 404 when route matches an abstract controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ You're really going to want to read this.
 
 ## 4.12.2 (2025-06-23)
 
+* Serve a generic 404 for URLs that happen to match abstract controller classes (instead of
+  throwing / alerting an unexpected exception). 
 * Fix further error case in `find_file` when cache read hits a race condition
   **NOTE** This adds a strict `array` typehint to the protected `Kohana_Core::$_files`.
 * Fix deprecation when attempting to delete a cookie by setting value to NULL

--- a/classes/Request/Executor.php
+++ b/classes/Request/Executor.php
@@ -115,10 +115,11 @@ class Request_Executor
 		$controller_refl = new ReflectionClass($class);
 
 		if ($controller_refl->isAbstract()) {
-			throw new Kohana_Exception(
-				'Cannot create instances of abstract :controller',
-				[':controller' => $class]
-			);
+			throw HTTP_Exception::factory(
+				404,
+				'The requested URL :uri was not found on this server.',
+				[':uri' => $request->uri()]
+			)->request($request);
 		}
 
 		return $controller_refl->newInstance($request, $response);

--- a/tests/kohana/request/ExecutorTest.php
+++ b/tests/kohana/request/ExecutorTest.php
@@ -27,13 +27,12 @@ class Kohana_Request_ExecutorTest extends TestCase
 		$subject->execute(Request::with(['uri' => 'no/controller']));
 	}
 
-	public function test_it_throws_generic_exception_if_controller_is_abstract()
+	public function test_it_throws_404_exception_if_controller_class_is_abstract()
 	{
 		$this->routes = [new Route('<controller>/<action>')];
 		$subject      = $this->newSubject();
 
-		$this->expectException(Kohana_Exception::class);
-		$this->expectExceptionMessage('abstract');
+		$this->expectException(HTTP_Exception_404::class);
 		$subject->execute(Request::with(['uri' => 'template/anything']));
 	}
 


### PR DESCRIPTION
Previously, this was throwing a generic exception, e.g. to alert that a developer had potentially mis-configured routing.

However, this generates spurious alerts if:

a) a project still registers default routes e.g.
   `(<controller>(/<action>(/<id>)))`
b) a crawler requests a URL that is not intended to be defined, but
   happens to match an abstract class e.g. `/template/whatever` =>
   Controller_Template (even if the project itself does not use
   Controller_Template).

It is more logical to treat this as a generic 404, the same as if the controller does not exist. User's functional testing should be sufficient to know that all *expected* URLs e.g. from links generated by the site are working as intended.